### PR TITLE
Beginning of overhaul efforts

### DIFF
--- a/coregrind/m_libcproc.c
+++ b/coregrind/m_libcproc.c
@@ -843,6 +843,15 @@ Int VG_(ptrace) ( Int request, Int pid, void *addr, void *data )
    Fork
    ------------------------------------------------------------------ */
 
+Addr VG_(mmap)(Addr addr, UWord length, Int prot, Int flags, Int fd, UWord offset) {
+   #if defined(VGO_linux)
+   SysRes res = VG_(do_syscall6)(__NR_mmap, addr, length, prot, flags, fd, offset);
+   return sr_Res(res);
+#  else
+#    error "Unknown OS"   
+#  endif
+}
+
 Int VG_(fork) ( void )
 {
 #  if defined(VGP_arm64_linux)

--- a/coregrind/m_libcproc.c
+++ b/coregrind/m_libcproc.c
@@ -843,9 +843,12 @@ Int VG_(ptrace) ( Int request, Int pid, void *addr, void *data )
    Fork
    ------------------------------------------------------------------ */
 
-void VG_(ftruncate)(HChar *path, UWord length) {
+void VG_(ftruncate)(Int fd, UWord length) {
    #if defined(VGO_linux)
-   SysRes res = VG_(do_syscall2)(__NR_ftruncate, path, length);
+   SysRes res = VG_(do_syscall2)(__NR_ftruncate, fd, length);
+   if (sr_isError(res)) {
+      VG_(emit)("ftruncate failed with errno: %d\n", sr_Err(res));
+   }
    #else
    #error Unknown OS
    #endif

--- a/include/pub_tool_libcproc.h
+++ b/include/pub_tool_libcproc.h
@@ -72,6 +72,8 @@ extern Int  VG_(system) ( const HChar* cmd );
 extern Int  VG_(spawn)  ( const HChar *filename, const HChar **argv );
 extern Int  VG_(fork)   ( void);
 extern Addr VG_(mmap)(Addr addr, UWord length, Int prot, Int flags, Int fd, UWord offset);
+extern Int VG_(munmap)(Addr addr, UWord length);
+extern void VG_(ftruncate)(HChar *path, UWord length);
 extern void VG_(execv)  ( const HChar* filename, const HChar** argv );
 extern Int  VG_(sysctl) ( Int *name, UInt namelen, void *oldp, SizeT *oldlenp, void *newp, SizeT newlen );
 

--- a/include/pub_tool_libcproc.h
+++ b/include/pub_tool_libcproc.h
@@ -71,6 +71,7 @@ extern Int  VG_(waitpid)( Int pid, Int *status, Int options );
 extern Int  VG_(system) ( const HChar* cmd );
 extern Int  VG_(spawn)  ( const HChar *filename, const HChar **argv );
 extern Int  VG_(fork)   ( void);
+extern Addr VG_(mmap)(Addr addr, UWord length, Int prot, Int flags, Int fd, UWord offset);
 extern void VG_(execv)  ( const HChar* filename, const HChar** argv );
 extern Int  VG_(sysctl) ( Int *name, UInt namelen, void *oldp, SizeT *oldlenp, void *newp, SizeT newlen );
 

--- a/include/pub_tool_libcproc.h
+++ b/include/pub_tool_libcproc.h
@@ -73,7 +73,7 @@ extern Int  VG_(spawn)  ( const HChar *filename, const HChar **argv );
 extern Int  VG_(fork)   ( void);
 extern Addr VG_(mmap)(Addr addr, UWord length, Int prot, Int flags, Int fd, UWord offset);
 extern Int VG_(munmap)(Addr addr, UWord length);
-extern void VG_(ftruncate)(HChar *path, UWord length);
+extern void VG_(ftruncate)(Int fd, UWord length);
 extern void VG_(execv)  ( const HChar* filename, const HChar** argv );
 extern Int  VG_(sysctl) ( Int *name, UInt namelen, void *oldp, SizeT *oldlenp, void *newp, SizeT newlen );
 

--- a/pmemcheck/pmat_tests/build.sh
+++ b/pmemcheck/pmat_tests/build.sh
@@ -1,0 +1,1 @@
+gcc -ggdb3 -fopenmp -O3 -std=gnu11 pmat_test.c

--- a/pmemcheck/pmat_tests/pmat_test.c
+++ b/pmemcheck/pmat_tests/pmat_test.c
@@ -8,7 +8,7 @@
 #include <libpmem.h>
 #include <valgrind/pmemcheck.h>
 
-#define N (1024)
+#define N (128)
 #define SIZE (N * sizeof(int))
 
 int main(int argc, char *argv[]) {

--- a/pmemcheck/pmat_tests/pmat_test.c
+++ b/pmemcheck/pmat_tests/pmat_test.c
@@ -8,7 +8,7 @@
 #include <libpmem.h>
 #include <valgrind/pmemcheck.h>
 
-#define N (128)
+#define N (1024)
 #define SIZE (N * sizeof(int))
 
 int main(int argc, char *argv[]) {

--- a/pmemcheck/pmat_tests/pmat_test.c
+++ b/pmemcheck/pmat_tests/pmat_test.c
@@ -1,0 +1,32 @@
+/*
+    Simple test to see if we can catch errors at end of program...
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <libpmem.h>
+#include <valgrind/pmemcheck.h>
+
+#define N (1024)
+#define SIZE (N * sizeof(int))
+
+int main(int argc, char *argv[]) {
+	size_t mapped_len;
+	int is_pmem;
+	int check;
+
+	/* create a pmem file and memory map it */
+	int *arr = malloc(SIZE);
+	VALGRIND_PMC_REGISTER("dummy.bin", arr, SIZE);
+
+	// Parallel Zero-Initialize over 'persistent' memory...
+	#pragma omp parallel for
+	for (int i = 0; i < N; i++) {
+		arr[i] = 0;
+		if (i % 8 == 0) asm volatile("clflush %0" : "+m" (*(volatile char *)(arr + i)));
+	}
+	asm volatile("sfence" : : : "memory");
+
+	return 0;
+}

--- a/pmemcheck/pmc_common.c
+++ b/pmemcheck/pmc_common.c
@@ -53,13 +53,13 @@ cmp_pmat_registered_files1(const void *key, const void *elem)
 {
     const struct pmat_registered_file *lhs = (const struct pmat_registered_file *) (key);    
     const struct pmat_registered_file *rhs = (const struct pmat_registered_file *) (elem);
-
-    if (rhs->addr < lhs->addr)
+    
+    if (lhs->addr + lhs->size <= rhs->addr)
         return -1;
-    else if (lhs->addr < rhs->addr) 
+    else if (lhs->addr >= rhs->addr + rhs->size)
         return 1;
     else
-        return 0; // laddr + size >= raddr && laddr <= raddr + rsize
+        return 0;
 }
 
 /**

--- a/pmemcheck/pmc_common.c
+++ b/pmemcheck/pmc_common.c
@@ -54,12 +54,12 @@ cmp_pmat_registered_files1(const void *key, const void *elem)
     const struct pmat_registered_file *lhs = (const struct pmat_registered_file *) (key);    
     const struct pmat_registered_file *rhs = (const struct pmat_registered_file *) (elem);
 
-    if (lhs->addr + lhs->size < rhs->addr)
+    if (rhs->addr < lhs->addr)
         return -1;
-    else if (lhs->addr > rhs->addr + rhs->size)
+    else if (lhs->addr < rhs->addr) 
         return 1;
     else
-        return 0;
+        return 0; // laddr + size >= raddr && laddr <= raddr + rsize
 }
 
 /**

--- a/pmemcheck/pmc_common.c
+++ b/pmemcheck/pmc_common.c
@@ -62,16 +62,6 @@ cmp_pmat_registered_files1(const void *key, const void *elem)
         return 0;
 }
 
-
-Word 
-cmp_pmat_registered_files2(const void *key, const void *elem) 
-{
-    const struct pmat_registered_file *lhs = (const struct pmat_registered_file *) (key);    
-    const struct pmat_registered_file *rhs = (const struct pmat_registered_file *) (elem);
-
-    return lhs->descr - rhs->descr;
-}
-
 /**
  * \brief Check if regions overlap.
  * \param lhs Region to check.

--- a/pmemcheck/pmc_include.h
+++ b/pmemcheck/pmc_include.h
@@ -32,6 +32,7 @@ struct pmem_st {
 
 struct pmat_cache_entry {
     // Bitmap to keep track of dirty bits
+    OSet *pending;
     Long dirtyBits;
     Addr addr;
     char data[0];

--- a/pmemcheck/pmc_include.h
+++ b/pmemcheck/pmc_include.h
@@ -40,6 +40,7 @@ struct pmat_cache_entry {
 typedef int (*pmat_verification_fn)(void *, SizeT sz);
 
 struct pmat_registered_file {
+    char *name;
     UWord descr;
     Addr addr; 
     UWord size;

--- a/pmemcheck/pmc_include.h
+++ b/pmemcheck/pmc_include.h
@@ -54,8 +54,8 @@ struct pmat_write_buffer_entry {
 
 // Converts addr to cache line addr
 #define CACHELINE_SIZE 64
-#define TRIM_CACHELINE(addr) (addr &~ (CACHELINE_SIZE - 1))
-#define OFFSET_CACHELINE(addr) (addr % CACHELINE_SIZE)
+#define TRIM_CACHELINE(addr) ((addr) &~ (CACHELINE_SIZE - 1))
+#define OFFSET_CACHELINE(addr) ((addr) % CACHELINE_SIZE)
 #define NUM_CACHE_ENTRIES 1024
 #define NUM_WB_ENTRIES 64
 

--- a/pmemcheck/pmc_include.h
+++ b/pmemcheck/pmc_include.h
@@ -32,7 +32,7 @@ struct pmem_st {
 
 struct pmat_cache_entry {
     // Bitmap to keep track of dirty bits
-    OSet *pending;
+    ExeContext *lastPendingStore;
     Long dirtyBits;
     Addr addr;
     char data[0];

--- a/pmemcheck/pmc_include.h
+++ b/pmemcheck/pmc_include.h
@@ -31,8 +31,10 @@ struct pmem_st {
 };
 
 struct pmat_cache_entry {
-   Addr addr;
-   char data[0];
+    // Bitmap to keep track of dirty bits
+    Long dirtyBits;
+    Addr addr;
+    char data[0];
 };
 
 typedef int (*pmat_verification_fn)(void *, SizeT sz);

--- a/pmemcheck/pmc_main.c
+++ b/pmemcheck/pmc_main.c
@@ -340,19 +340,28 @@ print_store_stats(void)
         ExeContext **context;
         VG_(OSetGen_ResetIter)(entry->pending);
         while ((context = VG_(OSetGen_Next)(entry->pending))) {
+            VG_(umsg)("~~~~~~~~~~~~~~~\n");
             VG_(pp_ExeContext)(*context);
+            VG_(umsg)("~~~~~~~~~~~~~~~\n");
         }
     }
 
     VG_(umsg)("Number of cache-lines flushed but not fenced: %u\n", VG_(OSetGen_Size)(pmem.pmat_write_buffer_entries));
-    VG_(OSetGen_ResetIter)(pmem.pmat_cache_entries);
-    entry = NULL;
-    while ((entry = VG_(OSetGen_Next)(pmem.pmat_cache_entries))) {
-        VG_(umsg)("Leaked Store to 0x%lx\n", entry->addr);
+    VG_(OSetGen_ResetIter)(pmem.pmat_write_buffer_entries);
+    struct pmat_write_buffer_entry *wbentry = NULL;
+    while ((wbentry = VG_(OSetGen_Next)(pmem.pmat_write_buffer_entries))) {
+        struct pmat_cache_entry *entry = wbentry->entry;
+        struct pmat_registered_file file;
+        file.addr = entry->addr;
+        struct pmat_registered_file *realFile = VG_(OSetGen_Lookup)(pmem.pmat_registered_files, &file);
+        tl_assert(realFile);
+        VG_(umsg)("Leaked Cache-Line at address 0x%lx belonging to file '%s'\n", entry->addr, realFile->name);
         ExeContext **context;
         VG_(OSetGen_ResetIter)(entry->pending);
         while ((context = VG_(OSetGen_Next)(entry->pending))) {
+            VG_(umsg)("~~~~~~~~~~~~~~~\n");
             VG_(pp_ExeContext)(*context);
+            VG_(umsg)("~~~~~~~~~~~~~~~\n");
         }
     }
 }

--- a/pmemcheck/pmemcheck.h
+++ b/pmemcheck/pmemcheck.h
@@ -51,7 +51,6 @@
 typedef
    enum {
        VG_USERREQ__PMC_REGISTER_PMEM_MAPPING = VG_USERREQ_TOOL_BASE('P','C'),
-       VG_USERREQ__PMC_FORCE_SIMULATE_CRASH,
        VG_USERREQ__PMC_REGISTER_PMEM_FILE,
        VG_USERREQ__PMC_REMOVE_PMEM_MAPPING,
        VG_USERREQ__PMC_CHECK_IS_PMEM_MAPPING,
@@ -66,8 +65,6 @@ typedef
        VG_USERREQ__PMC_RESERVED5,  /* Do not use. */
        VG_USERREQ__PMC_RESERVED7,  /* Do not use. */
        VG_USERREQ__PMC_RESERVED8,  /* Do not use. */
-       VG_USERREQ__PMC_RESERVED9,  /* Do not use. */
-       VG_USERREQ__PMC_RESERVED10, /* Do not use. */
        VG_USERREQ__PMC_SET_CLEAN,
        /* transaction support */
        VG_USERREQ__PMC_START_TX,
@@ -83,22 +80,13 @@ typedef
        VG_USERREQ__PMC_ADD_TO_GLOBAL_TX_IGNORE,
        VG_USERREQ__PMC_RESERVED6,  /* Do not use. */
        VG_USERREQ__PMC_EMIT_LOG,
-       VG_USERREQ__PMAT_REGISTER,
+       VG_USERREQ__PMC_PMAT_REGISTER,
+       VG_USERREQ__PMC_PMAT_FORCE_SIMULATE_CRASH
    } Vg_PMemCheckClientRequest;
 
 
 
 /* Client-code macros to manipulate pmem mappings */
-
-#define VALGRIND_PMC_FORCE_CRASH() \
-    VALGRIND_DO_CLIENT_REQUEST_STMT(VG_USERREQ__PMC_FORCE_SIMULATE_CRASH,  \
-                                    0, 0, 0, 0, 0)
-
-/** Register a verification function to a particular mapping */
-#define VG_USERREQ__PMAT_REGISTER(_qzz_name, _qzz_addr, _qzz_size) \
-    VALGRIND_DO_CLIENT_REQUEST_EXPR(0 /* default return */, \
-            VG_USERREQ__PMC_VERIFICATION, \
-            (_qzz_name), (_qzz_addr), (_qzz_size), 0, 0)
 
 /** Register a persistent memory mapping region */
 #define VALGRIND_PMC_REGISTER_PMEM_MAPPING(_qzz_addr, _qzz_len)             \
@@ -223,5 +211,15 @@ typedef
 #define VALGRIND_PMC_ADD_TO_GLOBAL_TX_IGNORE(_qzz_addr,_qzz_len)            \
     VALGRIND_DO_CLIENT_REQUEST_STMT(VG_USERREQ__PMC_ADD_TO_GLOBAL_TX_IGNORE,\
                                     (_qzz_addr), (_qzz_len), 0, 0, 0)
+
+/** Forces a simulated crash and starts recovery */
+#define VALGRIND_PMC_FORCE_CRASH() \
+    VALGRIND_DO_CLIENT_REQUEST_STMT(VG_USERREQ__PMC_PMAT_FORCE_SIMULATE_CRASH,  \
+                                    0, 0, 0, 0, 0)
+
+/** Register a verification function to a particular mapping */
+#define VALGRIND_PMC_REGISTER(_qzz_name, _qzz_addr, _qzz_size) \
+    VALGRIND_DO_CLIENT_REQUEST_STMT( VG_USERREQ__PMC_PMAT_REGISTER, \
+            (_qzz_name), (_qzz_addr), (_qzz_size), 0, 0)
 
 #endif

--- a/pmemcheck/pmemcheck.h
+++ b/pmemcheck/pmemcheck.h
@@ -83,7 +83,7 @@ typedef
        VG_USERREQ__PMC_ADD_TO_GLOBAL_TX_IGNORE,
        VG_USERREQ__PMC_RESERVED6,  /* Do not use. */
        VG_USERREQ__PMC_EMIT_LOG,
-       VG_USERREQ__PMC_VERIFICATION,
+       VG_USERREQ__PMAT_REGISTER,
    } Vg_PMemCheckClientRequest;
 
 
@@ -95,10 +95,10 @@ typedef
                                     0, 0, 0, 0, 0)
 
 /** Register a verification function to a particular mapping */
-#define VALGRIND_PMC_VERIFICATION(_qzz_addr) \
+#define VG_USERREQ__PMAT_REGISTER(_qzz_name, _qzz_addr, _qzz_size) \
     VALGRIND_DO_CLIENT_REQUEST_EXPR(0 /* default return */, \
             VG_USERREQ__PMC_VERIFICATION, \
-            (_qzz_addr), 0, 0, 0, 0)
+            (_qzz_name), (_qzz_addr), (_qzz_size), 0, 0)
 
 /** Register a persistent memory mapping region */
 #define VALGRIND_PMC_REGISTER_PMEM_MAPPING(_qzz_addr, _qzz_len)             \

--- a/pmemcheck/pmemcheck.h
+++ b/pmemcheck/pmemcheck.h
@@ -51,6 +51,7 @@
 typedef
    enum {
        VG_USERREQ__PMC_REGISTER_PMEM_MAPPING = VG_USERREQ_TOOL_BASE('P','C'),
+       VG_USERREQ__PMC_FORCE_SIMULATE_CRASH,
        VG_USERREQ__PMC_REGISTER_PMEM_FILE,
        VG_USERREQ__PMC_REMOVE_PMEM_MAPPING,
        VG_USERREQ__PMC_CHECK_IS_PMEM_MAPPING,
@@ -89,11 +90,15 @@ typedef
 
 /* Client-code macros to manipulate pmem mappings */
 
+#define VALGRIND_PMC_FORCE_CRASH() \
+    VALGRIND_DO_CLIENT_REQUEST_STMT(VG_USERREQ__PMC_FORCE_SIMULATE_CRASH,  \
+                                    0, 0, 0, 0, 0)
+
 /** Register a verification function to a particular mapping */
-#define VALGRIND_PMC_VERIFICATION(_qzz_addr, _qzz_fnptr) \
+#define VALGRIND_PMC_VERIFICATION(_qzz_addr) \
     VALGRIND_DO_CLIENT_REQUEST_EXPR(0 /* default return */, \
             VG_USERREQ__PMC_VERIFICATION, \
-            (_qzz_addr), (_qzz_fnptr), 0, 0, 0)
+            (_qzz_addr), 0, 0, 0, 0)
 
 /** Register a persistent memory mapping region */
 #define VALGRIND_PMC_REGISTER_PMEM_MAPPING(_qzz_addr, _qzz_len)             \


### PR DESCRIPTION
In this effort, I have done the following:

1) Created a new test in `pmemcheck/pmat_tests/` that tests A) How it interacts with third-party dynamic/static linked libraries, such as OpenMP, B) How the tool handles parallelism, and C) See how it handles reporting unflushed cache-lines.
2) Added new system calls for Linux only for `mmap`, `munmap`, and `ftruncate`
3) Removed the old and buggy `child_task` verification tool and am going for a much simpler method that is mentioned in the DESIGN.md document in pmem/3.14

